### PR TITLE
Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+!**/src/main/generated/
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-!**/src/main/generated/
+**/src/main/generated/**
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
## 개요
code conflict 및 build failed 의 주범인 디렉토리 ignore
ignore 대상에 `**/src/main/generated/**` 추가하여 main/generated/QClass....를 ignore 시킴.

